### PR TITLE
Fix placement task lifecycle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 # Fabric Properties
+org.gradle.java.installations.paths=E:/Coding/Minecraft/tools/jdk-25.0.3+9
 # check these on https://fabricmc.net/develop
 minecraft_version=26.2
 loader_version=0.19.2

--- a/src/main/java/com/tick_ins/tick/TickThread.java
+++ b/src/main/java/com/tick_ins/tick/TickThread.java
@@ -36,8 +36,11 @@ public final class TickThread {
         runAfterTick(() -> {
             if (second != null) {
                 runNow(() -> {
-                    second.task().run();
-                    clearLookLock();
+                    try {
+                        second.task().run();
+                    } finally {
+                        clearLookLock();
+                    }
                 });
             } else {
                 runNow(TickThread::clearLookLock);
@@ -55,8 +58,11 @@ public final class TickThread {
         runNow(task.task());
         runAfterTick(() -> {
             runNow(() -> {
-                task.cache().run();
-                clearLookLock();
+                try {
+                    task.cache().run();
+                } finally {
+                    clearLookLock();
+                }
             });
         }, 1);
     }
@@ -116,7 +122,6 @@ public final class TickThread {
     public static void onClientDisconnected() {
         TASK_EPOCH.incrementAndGet();
         clearLookLock();
-        clientStopping = false;
     }
 
     public static void onClientShutdown() {

--- a/src/main/java/org/uiop/easyplacefix/until/PlayerBlockAction.java
+++ b/src/main/java/org/uiop/easyplacefix/until/PlayerBlockAction.java
@@ -41,6 +41,7 @@ public class PlayerBlockAction {
         public static BlockState pistonBlockState = null;
         // Global placement rate limiter (anti-cheat protection)
         private static volatile long lastGlobalPlacementTime = 0;
+        private static volatile long lastPruneTime = 0;
         private static final long PLACEMENT_OVERRIDE_TTL_MS = 1200L;
         private static final int PLACEMENT_OVERRIDE_MAX_SIZE = 512;
         private static final int PLACEMENT_OVERRIDE_USES = 4;
@@ -191,8 +192,9 @@ public class PlayerBlockAction {
             long now = System.currentTimeMillis();
             long threshold = Ping2Server.getRtt() + 100;
 
-            // Prune stale entries to prevent memory leak (entries older than 10 seconds)
-            if (lastPlacementTimeMap.size() > 256) {
+            // Prune stale entries periodically to prevent memory leak and CPU bottleneck
+            if (now - lastPruneTime > 5000L) {
+                lastPruneTime = now;
                 lastPlacementTimeMap.entrySet().removeIf(e -> now - e.getValue() > 10_000L);
             }
 

--- a/src/main/java/org/uiop/easyplacefix/until/doEasyPlace.java
+++ b/src/main/java/org/uiop/easyplacefix/until/doEasyPlace.java
@@ -106,8 +106,7 @@ public class doEasyPlace {
                     stack1 = findBlockInInventory(playerInventory, predicate);
                 }
                 if (stack1 == null) {
-                    HashSet<ItemStack> itemStackHashSet = LoosenModeData.loadFromFile();
-                    return loosenMode2(itemStackHashSet);
+                    return loosenMode2(null);
 
                 }
                 return stack1;


### PR DESCRIPTION
## What changed
- Ensured look locks clear even when delayed placement actions throw.
- Prevented shutdown state from being reset during disconnect.
- Pruned placement timestamps periodically.
- Used cached loosen-mode item data and configured the Java 25 toolchain.

## Why
Exceptions could leave player look locked, and lifecycle ordering could re-enable queued work during shutdown.

## Impact
Placement actions recover safely from failures, and reconnect/shutdown behavior is deterministic.

## Checks
- `gradlew clean build --no-daemon --warning-mode all`